### PR TITLE
Upgrade unit tests to Junit5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 .gradle
-gradle.properties
 todo.txt
 
 # Created by https://www.gitignore.io/api/java,gradle

--- a/build.gradle
+++ b/build.gradle
@@ -44,14 +44,19 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
 
     // Test frameworks required for testing
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
-    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    testImplementation "org.junit.jupiter:junit-jupiter:${junit5Version}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoJunit5Version}"
+    testImplementation "org.assertj:assertj-core:${assertJCoreVersion}"
 
 }
 
 test {
     finalizedBy jacocoTestReport
+    useJUnitPlatform()
+    testLogging {
+        events = ["passed", "failed", "skipped"]
+    }
 }
 
 jacocoTestReport {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+junit5Version=5.7.1
+mockitoJunit5Version=3.8.0
+assertJCoreVersion=3.19.0

--- a/src/test/java/zw/co/paynow/constants/MobileMoneyMethodTest.java
+++ b/src/test/java/zw/co/paynow/constants/MobileMoneyMethodTest.java
@@ -1,16 +1,18 @@
 package zw.co.paynow.constants;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class MobileMoneyMethodTest {
+@DisplayName("Mobile Money Method Test")
+class MobileMoneyMethodTest {
 
     @Test
-    public void MobileMoneyMethodToString_CurrentConstantValuesSet_StatusToStringHasCorrectValue() {
-        assertEquals("ECOCASH", MobileMoneyMethod.ECOCASH.toString());
-        assertEquals("TELECASH", MobileMoneyMethod.TELECASH.toString());
-        assertEquals("ONEMONEY", MobileMoneyMethod.ONEMONEY.toString());
+    @DisplayName("Mobile Money Method ToString Current Constant Values Set Status ToString Has Correct Value")
+    void MobileMoneyMethodToString_CurrentConstantValuesSet_StatusToStringHasCorrectValue() {
+        assertThat(MobileMoneyMethod.ECOCASH.toString()).hasToString("ECOCASH");
+        assertThat(MobileMoneyMethod.TELECASH.toString()).hasToString("TELECASH");
+        assertThat(MobileMoneyMethod.ONEMONEY.toString()).hasToString("ONEMONEY");
     }
-
 }

--- a/src/test/java/zw/co/paynow/constants/PaynowUrlsTest.java
+++ b/src/test/java/zw/co/paynow/constants/PaynowUrlsTest.java
@@ -1,15 +1,17 @@
 package zw.co.paynow.constants;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class PaynowUrlsTest {
+@DisplayName("Paynow Urls Test")
+class PaynowUrlsTest {
 
     @Test
-    public void PaynowUrls_CurrentConstantValuesSet_StringsHaveCorrectValues() {
-        assertEquals("https://www.paynow.co.zw/interface/initiatetransaction", PaynowUrls.INITIATE_TRANSACTION);
-        assertEquals("https://www.paynow.co.zw/interface/remotetransaction", PaynowUrls.INITIATE_MOBILE_TRANSACTION);
+    @DisplayName("Paynow Urls Current Constant Values Set Strings Have Correct Values")
+    void PaynowUrls_CurrentConstantValuesSet_StringsHaveCorrectValues() {
+        assertThat(PaynowUrls.INITIATE_TRANSACTION).isEqualTo("https://www.paynow.co.zw/interface/initiatetransaction");
+        assertThat(PaynowUrls.INITIATE_MOBILE_TRANSACTION).isEqualTo("https://www.paynow.co.zw/interface/remotetransaction");
     }
-
 }

--- a/src/test/java/zw/co/paynow/constants/TransactionStatusTest.java
+++ b/src/test/java/zw/co/paynow/constants/TransactionStatusTest.java
@@ -1,99 +1,102 @@
 package zw.co.paynow.constants;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TransactionStatusTest {
+@DisplayName("Transaction Status Test")
+class TransactionStatusTest {
 
     @Test
-    public void GetResponseString_CurrentConstantValuesSet_ResponseStringReturnsCorrectValue() {
-        assertTrue("OK".equalsIgnoreCase(TransactionStatus.OK.getResponseString()));
-        assertTrue("PAID".equalsIgnoreCase(TransactionStatus.PAID.getResponseString()));
-        assertTrue("CANCELLED".equalsIgnoreCase(TransactionStatus.CANCELLED.getResponseString()));
-        assertTrue("SENT".equalsIgnoreCase(TransactionStatus.SENT.getResponseString()));
-        assertTrue("AWAITING DELIVERY".equalsIgnoreCase(TransactionStatus.DELIVERY.getResponseString()));
-        assertTrue("DISPUTED".equalsIgnoreCase(TransactionStatus.DISPUTED.getResponseString()));
-        assertTrue("REFUNDED".equalsIgnoreCase(TransactionStatus.REFUNDED.getResponseString()));
-        assertTrue("DELIVERED".equalsIgnoreCase(TransactionStatus.DELIVERED.getResponseString()));
-        assertTrue("ERROR".equalsIgnoreCase(TransactionStatus.ERROR.getResponseString()));
-        assertTrue("CREATED".equalsIgnoreCase(TransactionStatus.CREATED.getResponseString()));
-        assertTrue("INVALID ID.".equalsIgnoreCase(TransactionStatus.INVALID_ID.getResponseString()));
+    @DisplayName("Get Response String Current Constant Values Set Response String Returns Correct Value")
+    void GetResponseString_CurrentConstantValuesSet_ResponseStringReturnsCorrectValue() {
+        assertThat(TransactionStatus.OK.getResponseString()).isEqualToIgnoringCase("OK");
+        assertThat(TransactionStatus.PAID.getResponseString()).isEqualToIgnoringCase("PAID");
+        assertThat(TransactionStatus.CANCELLED.getResponseString()).isEqualToIgnoringCase("CANCELLED");
+        assertThat(TransactionStatus.SENT.getResponseString()).isEqualToIgnoringCase("SENT");
+        assertThat(TransactionStatus.DELIVERY.getResponseString()).isEqualToIgnoringCase("AWAITING DELIVERY");
+        assertThat(TransactionStatus.DISPUTED.getResponseString()).isEqualToIgnoringCase("DISPUTED");
+        assertThat(TransactionStatus.REFUNDED.getResponseString()).isEqualToIgnoringCase("REFUNDED");
+        assertThat(TransactionStatus.DELIVERED.getResponseString()).isEqualToIgnoringCase("DELIVERED");
+        assertThat(TransactionStatus.ERROR.getResponseString()).isEqualToIgnoringCase("ERROR");
+        assertThat(TransactionStatus.CREATED.getResponseString()).isEqualToIgnoringCase("CREATED");
+        assertThat(TransactionStatus.INVALID_ID.getResponseString()).isEqualToIgnoringCase("INVALID ID.");
     }
 
     @Test
-    public void GetTransactionStatus_SampleExpectedString_ReturnsCorrectStatusEnum() {
+    @DisplayName("Get Transaction Status Sample Expected String Returns Correct Status Enum")
+    void GetTransactionStatus_SampleExpectedString_ReturnsCorrectStatusEnum() {
         TransactionStatus transactionStatusOk = TransactionStatus.getTransactionStatus("Ok");
-        assertEquals(TransactionStatus.OK, transactionStatusOk);
+        assertThat(transactionStatusOk).isEqualTo(TransactionStatus.OK);
 
         TransactionStatus transactionStatusPaid = TransactionStatus.getTransactionStatus("PAID");
-        assertEquals(TransactionStatus.PAID, transactionStatusPaid);
+        assertThat(transactionStatusPaid).isEqualTo(TransactionStatus.PAID);
 
         TransactionStatus transactionStatusCancelled = TransactionStatus.getTransactionStatus("CANCELLED");
-        assertEquals(TransactionStatus.CANCELLED, transactionStatusCancelled);
+        assertThat(transactionStatusCancelled).isEqualTo(TransactionStatus.CANCELLED);
 
         TransactionStatus transactionStatusSent = TransactionStatus.getTransactionStatus("SENT");
-        assertEquals(TransactionStatus.SENT, transactionStatusSent);
+        assertThat(transactionStatusSent).isEqualTo(TransactionStatus.SENT);
 
         TransactionStatus transactionStatusDelivery = TransactionStatus.getTransactionStatus("AWAITING DELIVERY");
-        assertEquals(TransactionStatus.DELIVERY, transactionStatusDelivery);
+        assertThat(transactionStatusDelivery).isEqualTo(TransactionStatus.DELIVERY);
 
         TransactionStatus transactionStatusDisputed = TransactionStatus.getTransactionStatus("DISPUTED");
-        assertEquals(TransactionStatus.DISPUTED, transactionStatusDisputed);
+        assertThat(transactionStatusDisputed).isEqualTo(TransactionStatus.DISPUTED);
 
         TransactionStatus transactionStatusRefunded = TransactionStatus.getTransactionStatus("REFUNDED");
-        assertEquals(TransactionStatus.REFUNDED, transactionStatusRefunded);
+        assertThat(transactionStatusRefunded).isEqualTo(TransactionStatus.REFUNDED);
 
         TransactionStatus transactionStatusDelivered = TransactionStatus.getTransactionStatus("DELIVERED");
-        assertEquals(TransactionStatus.DELIVERED, transactionStatusDelivered);
+        assertThat(transactionStatusDelivered).isEqualTo(TransactionStatus.DELIVERED);
 
         TransactionStatus transactionStatusError = TransactionStatus.getTransactionStatus("ERROR");
-        assertEquals(TransactionStatus.ERROR, transactionStatusError);
+        assertThat(transactionStatusError).isEqualTo(TransactionStatus.ERROR);
 
         TransactionStatus transactionStatusCreated = TransactionStatus.getTransactionStatus("CREATED");
-        assertEquals(TransactionStatus.CREATED, transactionStatusCreated);
+        assertThat(transactionStatusCreated).isEqualTo(TransactionStatus.CREATED);
 
         TransactionStatus transactionStatusInvalidId = TransactionStatus.getTransactionStatus("INVALID ID.");
-        assertEquals(TransactionStatus.INVALID_ID, transactionStatusInvalidId);
-
+        assertThat(transactionStatusInvalidId).isEqualTo(TransactionStatus.INVALID_ID);
     }
 
     @Test
-    public void GetTransactionStatus_SampleNonExistentString_ReturnsUndefinedStatusEnum() {
+    @DisplayName("Get Transaction Status Sample Non Existent String Returns Undefined Status Enum")
+    void GetTransactionStatus_SampleNonExistentString_ReturnsUndefinedStatusEnum() {
         TransactionStatus transactionStatusInvalidId = TransactionStatus.getTransactionStatus("Some random text");
-        assertEquals(TransactionStatus.UNDEFINED, transactionStatusInvalidId);
+        assertThat(transactionStatusInvalidId).isEqualTo(TransactionStatus.UNDEFINED);
     }
 
     @Test
-    public void GetDescription_CurrentConstantValuesSet_DescriptionIsNotNull() {
-        assertThat(TransactionStatus.OK.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.PAID.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.CANCELLED.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.ERROR.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.DELIVERED.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.REFUNDED.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.DISPUTED.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.DELIVERY.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.SENT.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.CREATED.getDescription(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.INVALID_ID.getDescription(), not(isEmptyOrNullString()));
+    @DisplayName("Get Description Current Constant Values Set Description Is Not Null")
+    void GetDescription_CurrentConstantValuesSet_DescriptionIsNotNull() {
+        assertThat(TransactionStatus.OK.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.PAID.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.CANCELLED.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.ERROR.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.DELIVERED.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.REFUNDED.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.DISPUTED.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.DELIVERY.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.SENT.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.CREATED.getDescription()).isNotEmpty();
+        assertThat(TransactionStatus.INVALID_ID.getDescription()).isNotEmpty();
     }
 
     @Test
-    public void ToString_CurrentConstantValuesSet_ToStringIsNotNullOrEmpty() {
-        assertThat(TransactionStatus.OK.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.PAID.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.CANCELLED.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.ERROR.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.DELIVERED.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.REFUNDED.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.DISPUTED.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.DELIVERY.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.SENT.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.CREATED.toString(), not(isEmptyOrNullString()));
-        assertThat(TransactionStatus.INVALID_ID.toString(), not(isEmptyOrNullString()));
+    @DisplayName("To String Current Constant Values Set To String Is Not Null Or Empty")
+    void ToString_CurrentConstantValuesSet_ToStringIsNotNullOrEmpty() {
+        assertThat(TransactionStatus.OK.toString()).isNotEmpty();
+        assertThat(TransactionStatus.PAID.toString()).isNotEmpty();
+        assertThat(TransactionStatus.CANCELLED.toString()).isNotEmpty();
+        assertThat(TransactionStatus.ERROR.toString()).isNotEmpty();
+        assertThat(TransactionStatus.DELIVERED.toString()).isNotEmpty();
+        assertThat(TransactionStatus.REFUNDED.toString()).isNotEmpty();
+        assertThat(TransactionStatus.DISPUTED.toString()).isNotEmpty();
+        assertThat(TransactionStatus.DELIVERY.toString()).isNotEmpty();
+        assertThat(TransactionStatus.SENT.toString()).isNotEmpty();
+        assertThat(TransactionStatus.CREATED.toString()).isNotEmpty();
+        assertThat(TransactionStatus.INVALID_ID.toString()).isNotEmpty();
     }
-
 }

--- a/src/test/java/zw/co/paynow/constants/TransactionTypeTest.java
+++ b/src/test/java/zw/co/paynow/constants/TransactionTypeTest.java
@@ -1,15 +1,17 @@
 package zw.co.paynow.constants;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TransactionTypeTest {
+@DisplayName("Transaction Type Test")
+class TransactionTypeTest {
 
     @Test
-    public void ToString_CurrentConstantValuesSet_ToStringHasCorrectValue() {
-        assertEquals("WEB", TransactionType.WEB.toString());
-        assertEquals("MOBILE", TransactionType.MOBILE.toString());
+    @DisplayName("To String Current Constant Values Set To String Has Correct Value")
+    void ToString_CurrentConstantValuesSet_ToStringHasCorrectValue() {
+        assertThat(TransactionType.WEB.toString()).hasToString("WEB");
+        assertThat(TransactionType.MOBILE.toString()).hasToString("MOBILE");
     }
-
 }

--- a/src/test/java/zw/co/paynow/core/CoreTest.java
+++ b/src/test/java/zw/co/paynow/core/CoreTest.java
@@ -1,11 +1,12 @@
 package zw.co.paynow.core;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import zw.co.paynow.constants.MobileMoneyMethod;
 import zw.co.paynow.constants.PaynowUrls;
 import zw.co.paynow.constants.TransactionStatus;
@@ -25,14 +26,13 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
-public class CoreTest {
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Core Test")
+class CoreTest {
 
     private static String integrationKey;
     private static String integrationId;
@@ -46,8 +46,8 @@ public class CoreTest {
     @Mock
     private HttpClient httpClient;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         integrationKey = "0123456789";
         integrationId = "9876543210";
         resultUrl = "www.example.org/resultUrl";
@@ -55,8 +55,8 @@ public class CoreTest {
         dummyMobile = "0771222333";
     }
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         paynow = new Paynow(integrationId, integrationKey, resultUrl);
         paynow.setHttpHttpClient(httpClient);
 
@@ -73,133 +73,145 @@ public class CoreTest {
     }
 
     @Test
-    public void CreatePaymentMethods_ValidParams_PaymentObjectWithCorrectFieldValues() {
-
+    @DisplayName("Create Payment Methods Valid Params Payment Object With Correct Field Values")
+    void CreatePaymentMethods_ValidParams_PaymentObjectWithCorrectFieldValues() {
         Payment payment1 = paynow.createPayment("1");
-        assertEquals("1", payment1.getMerchantReference());
-        assertThat(payment1.getCart(), not(nullValue()));
-        assertEquals(0, payment1.getCart().size());
-        assertEquals("", payment1.getAuthEmail());
-
+        assertThat(payment1.getMerchantReference()).isEqualTo("1");
+        assertThat(payment1.getCart()).isNotNull();
+        assertThat(payment1.getCart().size()).isZero();
+        assertThat(payment1.getAuthEmail()).isEmpty();
         Payment payment2 = paynow.createPayment("1", dummyEmail);
-        assertEquals("1", payment2.getMerchantReference());
-        assertEquals(dummyEmail, payment2.getAuthEmail());
-        assertThat(payment2.getCart(), not(nullValue()));
-        assertEquals(0, payment2.getCart().size());
+        assertThat(payment2.getMerchantReference()).isEqualTo("1");
+        assertThat(payment2.getAuthEmail()).isEqualTo(dummyEmail);
+        assertThat(payment2.getCart()).isNotNull();
+        assertThat(payment2.getCart().size()).isZero();
 
         Payment payment3 = paynow.createPayment("1", dummyCart);
-        assertEquals("1", payment3.getMerchantReference());
-        assertThat(payment3.getCart(), not(nullValue()));
-        assertEquals(dummyCart, payment3.getCart());
-        assertEquals(dummyCart.size(), payment3.getCart().size());
-        assertEquals("", payment3.getAuthEmail());
-
+        assertThat(payment3.getMerchantReference()).isEqualTo("1");
+        assertThat(payment3.getCart()).isNotNull();
+        assertThat(payment3.getCart()).isEqualTo(dummyCart);
+        assertThat(payment3.getCart().size()).isEqualTo(dummyCart.size());
+        assertThat(payment3.getAuthEmail()).isEmpty();
         Payment payment4 = paynow.createPayment("1", dummyCart, dummyEmail);
-        assertEquals("1", payment4.getMerchantReference());
-        assertThat(payment4.getCart(), not(nullValue()));
-        assertEquals(dummyCart, payment4.getCart());
-        assertEquals(dummyCart.size(), payment4.getCart().size());
-        assertEquals(dummyEmail, payment4.getAuthEmail());
-
+        assertThat(payment4.getMerchantReference()).isEqualTo("1");
+        assertThat(payment4.getCart()).isNotNull();
+        assertThat(payment4.getCart()).isEqualTo(dummyCart);
+        assertThat(payment4.getCart().size()).isEqualTo(dummyCart.size());
+        assertThat(payment4.getAuthEmail()).isEqualTo(dummyEmail);
     }
 
-    @Test(expected = InvalidReferenceException.class)
-    public void CreatePaymentForWeb_PaymentWithEmptyReference_ExceptionThrown() {
-
+    @Test
+    @DisplayName("Create Payment For Web Payment With Empty Reference Exception Thrown")
+    void CreatePaymentForWeb_PaymentWithEmptyReference_ExceptionThrown() {
         dummyPayment = paynow.createPayment("", dummyEmail);
 
-        paynow.send(dummyPayment);
-
+        assertThrows(InvalidReferenceException.class, () -> paynow.send(dummyPayment));
     }
 
-    @Test(expected = InvalidReferenceException.class)
-    public void CreatePaymentForMobile_PaymentWithEmptyReference_ExceptionThrown() {
-
+    @Test
+    @DisplayName("Create Payment For Mobile Payment With Empty Reference Exception Thrown")
+    void CreatePaymentForMobile_PaymentWithEmptyReference_ExceptionThrown() {
         dummyPayment = paynow.createPayment("", dummyEmail);
 
-        paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
-
+        assertThrows(InvalidReferenceException.class, () -> paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void SendMobile_PaymentWithNoEmail_ExceptionThrown() {
+    @Test
+    @DisplayName("Send Mobile Payment With No Email Exception Thrown")
+    void SendMobile_PaymentWithNoEmail_ExceptionThrown() {
         dummyPayment = paynow.createPayment("1", "");
         dummyPayment.add("Bananas", new BigDecimal(1));
-        paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
+
+        assertThrows(IllegalArgumentException.class, () -> paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void SendMobile_PaymentWithBadEmail_ExceptionThrown() {
+    @Test
+    @DisplayName("Send Mobile Payment With Bad Email Exception Thrown")
+    void SendMobile_PaymentWithBadEmail_ExceptionThrown() {
         dummyPayment = paynow.createPayment("1", "bad@email");
         dummyPayment.add("Bananas", new BigDecimal(1));
-        paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
+
+        assertThrows(IllegalArgumentException.class, () -> paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void SendMobile_PaymentWithNullEmail_ExceptionThrown() {
+    @Test
+    @DisplayName("Send Mobile Payment With Null Email Exception Thrown")
+    void SendMobile_PaymentWithNullEmail_ExceptionThrown() {
         String nullString = null;
-        //noinspection ConstantConditions
+        // noinspection ConstantConditions
         dummyPayment = paynow.createPayment("1", nullString);
         dummyPayment.add("Bananas", new BigDecimal(1));
-        paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
+
+        assertThrows(IllegalArgumentException.class, () -> paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH));
     }
 
     @Test
-    public void ParseStatusWithStringAsArg_ValidResponseString_ParseStatusWithCorrectFieldValues() {
-
+    @DisplayName("Parse Status With String As Arg Valid Response String Parse Status With Correct Field Values")
+    void ParseStatusWithStringAsArg_ValidResponseString_ParseStatusWithCorrectFieldValues() {
         String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=DD982F5F279A97BE50E0156742804CAFA5E658E58AC0DB4B7D91C1B45E95A3B42475F91A249DDBEB1FF2FB69D80D3FAE3DC2289649B03ADEDEDB9624D444485E";
+
         StatusResponse statusResponse = paynow.parseStatus(rawResponse);
-        assertEquals("Invoice 32", statusResponse.getMerchantReference());
-        assertEquals("1234567", statusResponse.getPaynowReference());
-        assertEquals("Invoice 32", statusResponse.getMerchantReference());
-        assertEquals(new BigDecimal(3.5), statusResponse.getAmount());
-        assertFalse(statusResponse.paid());
-        assertThat(statusResponse.getRawResponseContent(), not(nullValue()));
-        assertEquals(6, statusResponse.getRawResponseContent().size());
-        assertEquals(UrlParser.parseMapFromQueryString(rawResponse), statusResponse.getRawResponseContent());
+
+        assertThat(statusResponse.getMerchantReference()).isEqualTo("Invoice 32");
+        assertThat(statusResponse.getPaynowReference()).isEqualTo("1234567");
+        assertThat(statusResponse.getMerchantReference()).isEqualTo("Invoice 32");
+        assertThat(statusResponse.getAmount()).isEqualTo(new BigDecimal("3.5"));
+        assertThat(statusResponse.paid()).isFalse();
+        assertThat(statusResponse.getRawResponseContent()).isNotNull();
+        assertThat(statusResponse.getRawResponseContent()).hasSize(6);
+        assertThat(statusResponse.getRawResponseContent()).isEqualTo(UrlParser.parseMapFromQueryString(rawResponse));
 
     }
 
     @Test
-    public void ParseStatusWithMapAsArg_ValidResponseString_ParseStatusWithCorrectFieldValues() {
-
+    @DisplayName("Parse Status With Map As Arg Valid Response String Parse Status With Correct Field Values")
+    void ParseStatusWithMapAsArg_ValidResponseString_ParseStatusWithCorrectFieldValues() {
         String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=DD982F5F279A97BE50E0156742804CAFA5E658E58AC0DB4B7D91C1B45E95A3B42475F91A249DDBEB1FF2FB69D80D3FAE3DC2289649B03ADEDEDB9624D444485E";
+
         HashMap<String, String> mapResponse = UrlParser.parseMapFromQueryString(rawResponse);
+
         StatusResponse statusResponse = paynow.parseStatus(mapResponse);
-        assertEquals("Invoice 32", statusResponse.getMerchantReference());
-        assertEquals("1234567", statusResponse.getPaynowReference());
-        assertEquals("Invoice 32", statusResponse.getMerchantReference());
-        assertEquals(new BigDecimal(3.5), statusResponse.getAmount());
-        assertFalse(statusResponse.paid());
-        assertThat(statusResponse.getRawResponseContent(), not(nullValue()));
-        assertEquals(6, statusResponse.getRawResponseContent().size());
-        assertEquals(UrlParser.parseMapFromQueryString(rawResponse), statusResponse.getRawResponseContent());
-
-    }
-
-    @Test(expected = HashMismatchException.class)
-    public void ParseStatusWithMapAsArg_BadHash_ExceptionThrown() {
-        String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=WrongHash";
-        HashMap<String, String> mapResponse = UrlParser.parseMapFromQueryString(rawResponse);
-        paynow.parseStatus(mapResponse);
-    }
-
-    @Test(expected = HashMismatchException.class)
-    public void ParseStatusWithMapAsArg_NoHashEntryInMap_ExceptionThrown() {
-        String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68";
-        HashMap<String, String> mapResponse = UrlParser.parseMapFromQueryString(rawResponse);
-        paynow.parseStatus(mapResponse);
-    }
-
-    @Test(expected = HashMismatchException.class)
-    public void ParseStatusWithStringAsArg_NoHashEntryInMap_ExceptionThrown() {
-        String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=WrongHash";
-        paynow.parseStatus(rawResponse);
+        assertThat(statusResponse.getMerchantReference()).isEqualTo("Invoice 32");
+        assertThat(statusResponse.getPaynowReference()).isEqualTo("1234567");
+        assertThat(statusResponse.getMerchantReference()).isEqualTo("Invoice 32");
+        assertThat(statusResponse.getAmount()).isEqualTo(new BigDecimal("3.5"));
+        assertThat(statusResponse.paid()).isFalse();
+        assertThat(statusResponse.getRawResponseContent()).isNotNull();
+        assertThat(statusResponse.getRawResponseContent()).hasSize(6);
+        assertThat(statusResponse.getRawResponseContent()).isEqualTo(UrlParser.parseMapFromQueryString(rawResponse));
     }
 
     @Test
-    public void SendForWeb_CorrectAndValidPaymentObj_ResponseIsReturnedWithCorrectValues() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    @DisplayName("Parse Status With Map As Arg Bad Hash Exception Thrown")
+    void ParseStatusWithMapAsArg_BadHash_ExceptionThrown() {
+        String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=WrongHash";
 
+        HashMap<String, String> mapResponse = UrlParser.parseMapFromQueryString(rawResponse);
+
+        assertThrows(HashMismatchException.class, () -> paynow.parseStatus(mapResponse));
+    }
+
+    @Test
+    @DisplayName("Parse Status With Map As Arg No Hash Entry In Map Exception Thrown")
+    void ParseStatusWithMapAsArg_NoHashEntryInMap_ExceptionThrown() {
+        String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68";
+
+        HashMap<String, String> mapResponse = UrlParser.parseMapFromQueryString(rawResponse);
+
+        assertThrows(HashMismatchException.class, () -> paynow.parseStatus(mapResponse));
+    }
+
+    @Test
+    @DisplayName("Parse Status With String As Arg No Hash Entry In Map Exception Thrown")
+    void ParseStatusWithStringAsArg_NoHashEntryInMap_ExceptionThrown() {
+        String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=WrongHash";
+
+        assertThrows(HashMismatchException.class, () -> paynow.parseStatus(rawResponse));
+    }
+
+    @Test
+    @DisplayName("Send For Web Correct And Valid Payment Obj Response Is Returned With Correct Values")
+    void SendForWeb_CorrectAndValidPaymentObj_ResponseIsReturnedWithCorrectValues() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         String rawResponse = "status=Ok&browserurl=https%3a%2f%2fwww.paynow.co.zw%2fPayment%2fConfirmPayment%2f2638504%2ftmoyo%40yahoo.com%2f%2f&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d09471727-37a6-4a0c-a7f3-c1ac48f79431&hash=CDC4027ED4E94CEF5B95DCC3A86A2BC071E0BDFD6C8B8E5323B8F93DD260CC0EC4195815985FCB767DDD2384E7F1AA331159E137928005A372B97D5CFA4562C7";
 
         //Access private method using reflection
@@ -213,18 +225,18 @@ public class CoreTest {
 
         verify(httpClient, times(1)).postAsync(PaynowUrls.INITIATE_TRANSACTION, data);
 
-        assertEquals(TransactionStatus.OK, response.getStatus());
-        assertTrue(response.success());
-        assertEquals(0, response.getErrors().size());
-        assertThat(response.getHash(), not(isEmptyOrNullString()));
-        assertThat(response.getRedirectURL(), not(isEmptyOrNullString()));
-        assertThat(response.getPollUrl(), not(isEmptyOrNullString()));
+        assertThat(response.getStatus()).isEqualTo(TransactionStatus.OK);
+        assertThat(response.success()).isTrue();
+        assertThat(response.getErrors()).isEmpty();
+        assertThat(response.getHash()).isNotEmpty();
+        assertThat(response.getRedirectURL()).isNotEmpty();
+        assertThat(response.getPollUrl()).isNotEmpty();
 
     }
 
     @Test
-    public void SendForMobile_CorrectAndValidPaymentObj_ResponseIsReturnedWithCorrectValues() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-
+    @DisplayName("Send For Mobile Correct And Valid Payment Obj Response Is Returned With Correct Values")
+    void SendForMobile_CorrectAndValidPaymentObj_ResponseIsReturnedWithCorrectValues() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         String rawResponse = "status=Ok&paynowreference=0123456&instructions=Some_random_instructions&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d09471727-37a6-4a0c-a7f3-c1ac48f79431&hash=DB191C4CDE56138E11A398CA6AB1E1FC5DEEA870FFDDE4557F2A8994EFF8BA284C5318BC2213AA65449B5565AC6FC6A164554E5463EDF0164D149A0E0D24AB8E";
 
         //Access private method using reflection
@@ -238,19 +250,18 @@ public class CoreTest {
 
         verify(httpClient, times(1)).postAsync(PaynowUrls.INITIATE_MOBILE_TRANSACTION, data);
 
-        assertEquals(TransactionStatus.OK, response.getStatus());
-        assertTrue(response.success());
-        assertEquals(0, response.getErrors().size());
-        assertEquals("0123456", response.getPaynowReference());
-        assertThat(response.getHash(), not(isEmptyOrNullString()));
-        assertThat(response.getInstructions(), not(isEmptyOrNullString()));
-        assertThat(response.getPollUrl(), not(isEmptyOrNullString()));
-
+        assertThat(response.getStatus()).isEqualTo(TransactionStatus.OK);
+        assertThat(response.success()).isTrue();
+        assertThat(response.getErrors()).isEmpty();
+        assertThat(response.getPaynowReference()).isEqualTo("0123456");
+        assertThat(response.getHash()).isNotEmpty();
+        assertThat(response.getInstructions()).isNotEmpty();
+        assertThat(response.getPollUrl()).isNotEmpty();
     }
 
     @Test
-    public void PollTransaction_ValidResponseString_ResponseIsReturnedWithCorrectValues() throws IOException {
-
+    @DisplayName("Poll Transaction Valid Response String Response Is Returned With Correct Values")
+    void PollTransaction_ValidResponseString_ResponseIsReturnedWithCorrectValues() throws IOException {
         String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=DD982F5F279A97BE50E0156742804CAFA5E658E58AC0DB4B7D91C1B45E95A3B42475F91A249DDBEB1FF2FB69D80D3FAE3DC2289649B03ADEDEDB9624D444485E";
         String pollUrl = "www.dummypollurl.co.zw";
 
@@ -259,113 +270,109 @@ public class CoreTest {
         StatusResponse statusResponse = paynow.pollTransaction(pollUrl);
 
         verify(httpClient, times(1)).postAsync(pollUrl, null);
-
-        assertEquals("Invoice 32", statusResponse.getMerchantReference());
-        assertEquals("1234567", statusResponse.getPaynowReference());
-        assertEquals("Invoice 32", statusResponse.getMerchantReference());
-        assertEquals(new BigDecimal(3.5), statusResponse.getAmount());
-        assertFalse(statusResponse.paid());
-        assertThat(statusResponse.getRawResponseContent(), not(nullValue()));
-        assertEquals(6, statusResponse.getRawResponseContent().size());
-        assertEquals(UrlParser.parseMapFromQueryString(rawResponse), statusResponse.getRawResponseContent());
-
+        assertThat(statusResponse.getMerchantReference()).isEqualTo("Invoice 32");
+        assertThat(statusResponse.getPaynowReference()).isEqualTo("1234567");
+        assertThat(statusResponse.getMerchantReference()).isEqualTo("Invoice 32");
+        assertThat(statusResponse.getAmount()).isEqualTo(new BigDecimal("3.5"));
+        assertThat(statusResponse.paid()).isFalse();
+        assertThat(statusResponse.getRawResponseContent()).isNotNull();
+        assertThat(statusResponse.getRawResponseContent()).hasSize(6);
+        assertThat(statusResponse.getRawResponseContent()).isEqualTo(UrlParser.parseMapFromQueryString(rawResponse));
     }
 
-    @Test(expected = HashMismatchException.class)
-    public void SendForWeb_PaymentObjWithBadHash_ExceptionIsThrown() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-
+    @Test
+    @DisplayName("Send For Web Payment Obj With Bad Hash Exception Is Thrown")
+    void SendForWeb_PaymentObjWithBadHash_ExceptionIsThrown() throws Exception {
         String rawResponse = "status=Ok&browserurl=https%3a%2f%2fwww.paynow.co.zw%2fPayment%2fConfirmPayment%2f2638504%2ftmoyo%40yahoo.com%2f%2f&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d09471727-37a6-4a0c-a7f3-c1ac48f79431&hash=Wronghash";
 
-        //Access private method using reflection
+        // Access private method using reflection
         Method privateMethod = paynow.getClass().getDeclaredMethod("formatInitWebTransactionRequest", Payment.class);
         privateMethod.setAccessible(true);
-        @SuppressWarnings("unchecked") HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment);
-
+        @SuppressWarnings("unchecked")
+        HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment);
         when(httpClient.postAsync(PaynowUrls.INITIATE_TRANSACTION, data)).thenReturn(rawResponse);
 
-        paynow.send(dummyPayment);
-
+        assertThrows(HashMismatchException.class, () -> paynow.send(dummyPayment));
     }
 
-    @Test(expected = HashMismatchException.class)
-    public void SendForMobile_PaymentObjWithBadHash_ExceptionIsThrown() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-
+    @Test
+    @DisplayName("Send For Mobile Payment Obj With Bad Hash Exception Is Thrown")
+    void SendForMobile_PaymentObjWithBadHash_ExceptionIsThrown() throws Exception {
         String rawResponse = "status=Ok&paynowreference=0123456&instructions=Some_random_instructions&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d09471727-37a6-4a0c-a7f3-c1ac48f79431&hash=WrongHash";
 
-        //Access private method using reflection
+        // Access private method using reflection
         Method privateMethod = paynow.getClass().getDeclaredMethod("formatInitMobileTransactionRequest", Payment.class, String.class, MobileMoneyMethod.class);
         privateMethod.setAccessible(true);
-        @SuppressWarnings("unchecked") HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
-
+        @SuppressWarnings("unchecked")
+        HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
         when(httpClient.postAsync(PaynowUrls.INITIATE_MOBILE_TRANSACTION, data)).thenReturn(rawResponse);
 
-        paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
-
+        assertThrows(HashMismatchException.class, () -> paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH));
     }
 
-    @Test(expected = ConnectionException.class)
-    public void SendForMobile_ExceptionOccursDuringExecution_ExceptionIsCaughtAndCustomExceptionIsThrown() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-
-        //Access private method using reflection
+    @Test
+    @DisplayName("Send For Mobile Exception Occurs During Execution Exception Is Caught And Custom Exception Is Thrown")
+    void SendForMobile_ExceptionOccursDuringExecution_ExceptionIsCaughtAndCustomExceptionIsThrown() throws Exception {
+        // Access private method using reflection
         Method privateMethod = paynow.getClass().getDeclaredMethod("formatInitMobileTransactionRequest", Payment.class, String.class, MobileMoneyMethod.class);
         privateMethod.setAccessible(true);
-        @SuppressWarnings("unchecked") HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
-
+        @SuppressWarnings("unchecked")
+        HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
         when(httpClient.postAsync(PaynowUrls.INITIATE_MOBILE_TRANSACTION, data)).thenThrow(new IOException());
 
-        paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
-
+        assertThrows(ConnectionException.class, () -> paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH));
     }
 
-    @Test(expected = ConnectionException.class)
-    public void SendForWeb_ExceptionOccursDuringExecution_ExceptionIsCaughtAndCustomExceptionIsThrown() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-
-        //Access private method using reflection
+    @Test
+    @DisplayName("Send For Web Exception Occurs During Execution Exception Is Caught And Custom Exception Is Thrown")
+    void SendForWeb_ExceptionOccursDuringExecution_ExceptionIsCaughtAndCustomExceptionIsThrown() throws Exception {
+        // Access private method using reflection
         Method privateMethod = paynow.getClass().getDeclaredMethod("formatInitWebTransactionRequest", Payment.class);
         privateMethod.setAccessible(true);
-        @SuppressWarnings("unchecked") HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment);
-
+        @SuppressWarnings("unchecked")
+        HashMap<String, String> data = (HashMap<String, String>) privateMethod.invoke(paynow, dummyPayment);
         when(httpClient.postAsync(PaynowUrls.INITIATE_TRANSACTION, data)).thenThrow(new IOException());
 
-        paynow.send(dummyPayment);
-
-    }
-
-    @Test(expected = EmptyCartException.class)
-    public void SendForWeb_EmptyCart_ExceptionThrown() {
-        dummyPayment.getCart().clear();
-        paynow.send(dummyPayment);
-    }
-
-    @Test(expected = EmptyCartException.class)
-    public void SendForMobile_EmptyCart_ExceptionThrown() {
-        dummyPayment.getCart().clear();
-        paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH);
+        assertThrows(ConnectionException.class, () -> paynow.send(dummyPayment));
     }
 
     @Test
-    public void CalculateTotal_CartItemsSetInInit_CorrectTotal() {
+    @DisplayName("Send For Web Empty Cart Exception Thrown")
+    void SendForWeb_EmptyCart_ExceptionThrown() {
+        dummyPayment.getCart().clear();
 
+        assertThrows(EmptyCartException.class, () -> paynow.send(dummyPayment));
+    }
+
+    @Test
+    @DisplayName("Send For Mobile Empty Cart Exception Thrown")
+    void SendForMobile_EmptyCart_ExceptionThrown() {
+        dummyPayment.getCart().clear();
+
+        assertThrows(EmptyCartException.class, () -> paynow.sendMobile(dummyPayment, dummyMobile, MobileMoneyMethod.ECOCASH));
+    }
+
+    @Test
+    @DisplayName("Calculate Total Cart Items Set In Init Correct Total")
+    void CalculateTotal_CartItemsSetInInit_CorrectTotal() {
         BigDecimal total = dummyPayment.calculateTotal();
 
-        assertTrue(new BigDecimal(6).compareTo(total) == 0);
+        assertThat(total).isEqualByComparingTo(new BigDecimal(6));
 
     }
 
     @Test
-    public void ToDictionary_NoParams_CorrectValues() {
-
+    @DisplayName("To Dictionary No Params Correct Values")
+    void ToDictionary_NoParams_CorrectValues() {
         HashMap<String, String> map = dummyPayment.toDictionary();
-
-        assertEquals("", map.get("resulturl"));
-        assertEquals("", map.get("returnurl"));
-        assertEquals("1", map.get("reference"));
-        assertEquals("6.00", map.get("amount"));
-        assertEquals("", map.get("id"));
-        assertEquals("Apple, Bananas, Oranges", map.get("additionalinfo"));
-        assertEquals(dummyEmail, map.get("authemail"));
-        assertEquals("Message", map.get("status"));
-
+        assertThat(map.get("resulturl")).isEmpty();
+        assertThat(map.get("returnurl")).isEmpty();
+        assertThat(map.get("reference")).isEqualTo("1");
+        assertThat(map.get("amount")).isEqualTo("6.00");
+        assertThat(map.get("id")).isEmpty();
+        assertThat(map.get("additionalinfo")).isEqualTo("Apple, Bananas, Oranges");
+        assertThat(map.get("authemail")).isEqualTo(dummyEmail);
+        assertThat(map.get("status")).isEqualTo("Message");
     }
 
 }

--- a/src/test/java/zw/co/paynow/core/HashGeneratorTest.java
+++ b/src/test/java/zw/co/paynow/core/HashGeneratorTest.java
@@ -1,72 +1,77 @@
 package zw.co.paynow.core;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class HashGeneratorTest {
+@DisplayName("Hash Generator Test")
+class HashGeneratorTest {
 
     private static String dummyText;
-    private static Map<String, String> dummyValues = new HashMap<>();
+    private static final Map<String, String> dummyValues = new HashMap<>();
     private static String integrationKey;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         dummyText = "0123456789";
         integrationKey = "0123456789";
-
         dummyValues.put("item1", "value1");
         dummyValues.put("item2", "value2");
         dummyValues.put("item3", "value3");
     }
 
     @Test
-    public void MakeMethod_SampleIntegrationKeyAndMap_GeneratedHashIsNotNullOrEmpty() {
+    @DisplayName("Make Method Sample Integration Key And Map Generated Hash Is Not Null Or Empty")
+    void MakeMethod_SampleIntegrationKeyAndMap_GeneratedHashIsNotNullOrEmpty() {
         String integrationKey = "0123456789";
         String generatedHash = HashGenerator.make(dummyValues, integrationKey);
-        assertThat(generatedHash, not(isEmptyOrNullString()));
+        assertThat(generatedHash).isNotEmpty();
     }
 
     @Test
-    public void GenerateHashMethod_SampleText_GeneratedHashIsNotNullOrEmpty() {
+    @DisplayName("Generate Hash Method Sample Text Generated Hash Is Not Null Or Empty")
+    void GenerateHashMethod_SampleText_GeneratedHashIsNotNullOrEmpty() {
         String generatedHash = HashGenerator.generateHash(dummyText);
-        assertThat(generatedHash, not(isEmptyOrNullString()));
+        assertThat(generatedHash).isNotEmpty();
     }
 
     @Test
-    public void GenerateHashMethod_SampleText_GeneratedHashIsValidSHA512Hash() {
+    @DisplayName("Generate Hash Method Sample Text Generated Hash Is Valid SHA 512 Hash")
+    void GenerateHashMethod_SampleText_GeneratedHashIsValidSHA512Hash() {
         String generatedHash = HashGenerator.generateHash(dummyText);
-        assertEquals(128, generatedHash.length());
+        assertThat(generatedHash).hasSize(128);
     }
 
     @Test
-    public void GenerateHashMethod_SampleText_GeneratedHashIsCorrectHash() {
+    @DisplayName("Generate Hash Method Sample Text Generated Hash Is Correct Hash")
+    void GenerateHashMethod_SampleText_GeneratedHashIsCorrectHash() {
         String generatedHash = HashGenerator.generateHash(dummyText);
-        assertEquals("BB96C2FC40D2D54617D6F276FEBE571F623A8DADF0B734855299B0E107FDA32CF6B69F2DA32B36445D73690B93CBD0F7BFC20E0F7F28553D2A4428F23B716E90", generatedHash);
+        assertThat(generatedHash).isEqualTo("BB96C2FC40D2D54617D6F276FEBE571F623A8DADF0B734855299B0E107FDA32CF6B69F2DA32B36445D73690B93CBD0F7BFC20E0F7F28553D2A4428F23B716E90");
     }
 
     @Test
-    public void VerifyMethod_SampleMap_VerificationReturnsCorrectResult() {
+    @DisplayName("Verify Method Sample Map Verification Returns Correct Result")
+    void VerifyMethod_SampleMap_VerificationReturnsCorrectResult() {
         String correctHashUsingDummyValuesAndKey = "D7B2E3E63D1DE252C3DDC16546EA4DE6FC5DA5CB7DA3CA27FA982BC6F1B4972934AF583FE4EE7BDD59378BC0DB1A236D0D66194A90B5BB015EE5DA60FEAB2A1C";
         dummyValues.put("hash", correctHashUsingDummyValuesAndKey);
 
         boolean result = HashGenerator.verify(dummyValues, integrationKey);
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
-    public void VerifyMethod_SampleMap_VerificationReturnsFalseResult() {
+    @DisplayName("Verify Method Sample Map Verification Returns False Result")
+    void VerifyMethod_SampleMap_VerificationReturnsFalseResult() {
         String wrongHashUsingDummyValuesAndKey = "D7B2E3E63D1DE25FC3DDC16546EA4DE6FC5DA5PB7DA3CA27FA982BC6F1B4972934AF583FE4EE7BDD59378BC0DB1A236D0D66194A90B5BB015EE5DA60FEAB2A1C";
         dummyValues.put("hash", wrongHashUsingDummyValuesAndKey);
 
         boolean result = HashGenerator.verify(dummyValues, integrationKey);
-        assertFalse(result);
+        assertThat(result).isFalse();
     }
 
 }

--- a/src/test/java/zw/co/paynow/core/PaymentTest.java
+++ b/src/test/java/zw/co/paynow/core/PaymentTest.java
@@ -1,32 +1,31 @@
 package zw.co.paynow.core;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class PaymentTest {
+@DisplayName("Payment Test")
+class PaymentTest {
 
     private static String dummyEmail;
     private static HashMap<String, BigDecimal> dummyCart;
     private static String dummyMobile;
     private static Payment dummyPayment;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         dummyEmail = "example@example.org";
         dummyMobile = "0771222333";
     }
 
-    @Before
-    public void init() {
-
+    @BeforeEach
+    void init() {
         dummyPayment = new Payment("some_reference", dummyEmail);
         dummyPayment.add("Bananas", new BigDecimal(1));
         dummyPayment.add("Apple", new BigDecimal(2));
@@ -40,90 +39,86 @@ public class PaymentTest {
     }
 
     @Test
-    public void PaymentConstructors_ValidParams_PaymentObjectWithCorrectFieldValues() {
-
+    @DisplayName("Payment Constructors Valid Params Payment Object With Correct Field Values")
+    void PaymentConstructors_ValidParams_PaymentObjectWithCorrectFieldValues() {
         Payment payment1 = new Payment("1", dummyEmail);
-        assertEquals("1", payment1.getMerchantReference());
-        assertEquals(dummyEmail, payment1.getAuthEmail());
-        assertThat(payment1.getCart(), not(nullValue()));
-        assertEquals(0, payment1.getCart().size());
+        assertThat(payment1.getMerchantReference()).isEqualTo("1");
+        assertThat(payment1.getAuthEmail()).isEqualTo(dummyEmail);
+        assertThat(payment1.getCart()).isNotNull();
+        assertThat(payment1.getCart().size()).isZero();
 
         Payment payment2 = new Payment("1", dummyCart, dummyEmail);
-        assertEquals("1", payment2.getMerchantReference());
-        assertThat(payment2.getCart(), not(nullValue()));
-        assertEquals(dummyCart, payment2.getCart());
-        assertEquals(dummyCart.size(), payment2.getCart().size());
-        assertEquals(dummyEmail, payment2.getAuthEmail());
+        assertThat(payment2.getMerchantReference()).isEqualTo("1");
+        assertThat(payment2.getCart()).isNotNull();
+        assertThat(payment2.getCart()).isEqualTo(dummyCart);
+        assertThat(payment2.getCart().size()).isEqualTo(dummyCart.size());
+        assertThat(payment2.getAuthEmail()).isEqualTo(dummyEmail);
 
     }
 
     @Test
-    public void AddUsingStringAndDouble_ValidParams_CartWithOneNewEntry() {
-
+    @DisplayName("Add Using String And Double Valid Params Cart With One New Entry")
+    void AddUsingStringAndDouble_ValidParams_CartWithOneNewEntry() {
         int currentCartSize = dummyPayment.getCart().size();
         dummyPayment.add("Coconuts", 3.2);
-
-        assertEquals(currentCartSize + 1, dummyPayment.getCart().size());
-        assertTrue(dummyPayment.getCart().containsKey("Coconuts"));
-        assertTrue(dummyPayment.getCart().get("Coconuts").compareTo(new BigDecimal(3.2)) == 0);
-
+        assertThat(dummyPayment.getCart().size()).isEqualTo(currentCartSize + 1);
+        assertThat(dummyPayment.getCart()).containsKey("Coconuts");
+        assertThat(dummyPayment.getCart().get("Coconuts")).isEqualByComparingTo(new BigDecimal(3.2));
     }
 
     @Test
-    public void AddUsingStringAndInt_ValidParams_CartWithOneNewEntry() {
-
+    @DisplayName("Add Using String And Int Valid Params Cart With One New Entry")
+    void AddUsingStringAndInt_ValidParams_CartWithOneNewEntry() {
         int currentCartSize = dummyPayment.getCart().size();
         dummyPayment.add("Coconuts", 5);
 
-        assertEquals(currentCartSize + 1, dummyPayment.getCart().size());
-        assertTrue(dummyPayment.getCart().containsKey("Coconuts"));
-        assertTrue(dummyPayment.getCart().get("Coconuts").compareTo(new BigDecimal(5)) == 0);
+        assertThat(dummyPayment.getCart().size()).isEqualTo(currentCartSize + 1);
+        assertThat(dummyPayment.getCart()).containsKey("Coconuts");
+        assertThat(dummyPayment.getCart().get("Coconuts")).isEqualByComparingTo(new BigDecimal(5));
 
     }
 
     @Test
-    public void AddUsingStringAndBigDecimal_ValidParams_CartWithOneNewEntry() {
-
+    @DisplayName("Add Using String And Big Decimal Valid Params Cart With One New Entry")
+    void AddUsingStringAndBigDecimal_ValidParams_CartWithOneNewEntry() {
         int currentCartSize = dummyPayment.getCart().size();
         dummyPayment.add("Coconuts", new BigDecimal(8));
 
-        assertEquals(currentCartSize + 1, dummyPayment.getCart().size());
-        assertTrue(dummyPayment.getCart().containsKey("Coconuts"));
-        assertTrue(dummyPayment.getCart().get("Coconuts").compareTo(new BigDecimal(8)) == 0);
+        assertThat(dummyPayment.getCart().size()).isEqualTo(currentCartSize + 1);
+        assertThat(dummyPayment.getCart()).containsKey("Coconuts");
+        assertThat(dummyPayment.getCart().get("Coconuts")).isEqualByComparingTo(new BigDecimal(8));
 
     }
 
     @Test
-    public void Remove_ExistingCartItemAsParam_CartWithOneNewEntry() {
-
+    @DisplayName("Remove Existing Cart Item As Param Cart With One New Entry")
+    void Remove_ExistingCartItemAsParam_CartWithOneNewEntry() {
         int currentCartSize = dummyPayment.getCart().size();
         dummyPayment.remove("Bananas");
 
-        assertEquals(currentCartSize - 1, dummyPayment.getCart().size());
-        assertTrue(!dummyPayment.getCart().containsKey("Bananas"));
+        assertThat(dummyPayment.getCart().size()).isEqualTo(currentCartSize - 1);
+        assertThat(dummyPayment.getCart()).doesNotContainKey("Bananas");
 
     }
 
     @Test
-    public void Remove_NoneExistingCartItemAsParam_CartWithOneNewEntry() {
-
+    @DisplayName("Remove None Existing Cart Item As Param Cart With One New Entry")
+    void Remove_NoneExistingCartItemAsParam_CartWithOneNewEntry() {
         int currentCartSize = dummyPayment.getCart().size();
         dummyPayment.remove("Coconuts");
 
-        assertEquals(currentCartSize, dummyPayment.getCart().size());
-        assertTrue(!dummyPayment.getCart().containsKey("Coconuts"));
+        assertThat(dummyPayment.getCart().size()).isEqualTo(currentCartSize);
+        assertThat(dummyPayment.getCart()).doesNotContainKey("Coconuts");
 
     }
 
     @Test
-    public void SetCartDescription_NewDescriptionAsParam_NewDescription() {
-
+    @DisplayName("Set Cart Description New Description As Param New Description")
+    void SetCartDescription_NewDescriptionAsParam_NewDescription() {
         String newDescription = "Some new description";
         dummyPayment.setCartDescription(newDescription);
 
-        assertTrue(dummyPayment.isOverrideDescription());
-        assertEquals("Some new description", dummyPayment.getCartDescription());
-
+        assertThat(dummyPayment.isOverrideDescription()).isTrue();
+        assertThat(dummyPayment.getCartDescription()).isEqualTo("Some new description");
     }
-
 }

--- a/src/test/java/zw/co/paynow/core/PaynowTest.java
+++ b/src/test/java/zw/co/paynow/core/PaynowTest.java
@@ -1,117 +1,120 @@
 package zw.co.paynow.core;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import zw.co.paynow.exceptions.ConnectionException;
 import zw.co.paynow.exceptions.HashMismatchException;
 import zw.co.paynow.http.HttpClient;
 
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class PaynowTest {
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Paynow Test")
+class PaynowTest {
 
     private static String integrationKey;
+
     private static String integrationId;
+
     private static String resultUrl;
+
     private static Paynow paynow;
 
     @Mock
     private HttpClient httpClient;
 
-    @BeforeClass
-    public static void setup() {
+    @BeforeAll
+    static void setup() {
         integrationKey = "0123456789";
         integrationId = "9876543210";
         resultUrl = "www.example.org/resultUrl";
     }
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         paynow = new Paynow(integrationId, integrationKey, resultUrl);
         paynow.setHttpHttpClient(httpClient);
     }
 
     @Test
-    public void PaynowConstructors_ExpectedParams_PaynowObjectWithCorrectFieldValues() {
-
+    @DisplayName("Paynow Constructors Expected Params Paynow Object With Correct Field Values")
+    void PaynowConstructors_ExpectedParams_PaynowObjectWithCorrectFieldValues() {
         Paynow paynow1 = new Paynow(integrationId, integrationKey);
-        assertThat(paynow1, not(nullValue()));
-        assertEquals(integrationId, paynow1.getIntegrationId());
-        assertEquals(integrationKey, paynow1.getIntegrationKey());
-        assertEquals("http://localhost", paynow1.getResultUrl());
-        assertThat(paynow1.getHttpHttpClient(), not(nullValue()));
+        assertThat(paynow1).isNotNull();
+        assertThat(paynow1.getIntegrationId()).isEqualTo(integrationId);
+        assertThat(paynow1.getIntegrationKey()).isEqualTo(integrationKey);
+        assertThat(paynow1.getResultUrl()).isEqualTo("http://localhost");
+        assertThat(paynow1.getHttpHttpClient()).isNotNull();
 
         Paynow paynow2 = new Paynow(integrationId, integrationKey, resultUrl);
-        assertThat(paynow2, not(nullValue()));
-        assertEquals(integrationId, paynow2.getIntegrationId());
-        assertEquals(integrationKey, paynow2.getIntegrationKey());
-        assertEquals(resultUrl, paynow2.getResultUrl());
-        assertThat(paynow2.getHttpHttpClient(), not(nullValue()));
+        assertThat(paynow2).isNotNull();
+        assertThat(paynow2.getIntegrationId()).isEqualTo(integrationId);
+        assertThat(paynow2.getIntegrationKey()).isEqualTo(integrationKey);
+        assertThat(paynow2.getResultUrl()).isEqualTo(resultUrl);
+        assertThat(paynow2.getHttpHttpClient()).isNotNull();
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void PaynowConstructorWithTwoParams_NoIntegrationId_ExceptionThrown() {
-        new Paynow("", "lorem_ipsum");
+    @Test
+    @DisplayName("Paynow Constructor With Two Params No Integration Id Exception Thrown")
+    void PaynowConstructorWithTwoParams_NoIntegrationId_ExceptionThrown() {
+        assertThrows(IllegalArgumentException.class, () -> new Paynow("", "lorem_ipsum"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void PaynowConstructorTwoParam_NoIntegrationKey_ExceptionThrown() {
-        new Paynow("lorem_ipsum", "");
+    @Test
+    @DisplayName("Paynow Constructor Two Param No Integration Key Exception Thrown")
+    void PaynowConstructorTwoParam_NoIntegrationKey_ExceptionThrown() {
+        assertThrows(IllegalArgumentException.class, () -> new Paynow("lorem_ipsum", ""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void PaynowConstructorThreeParam_NoIntegrationId_ExceptionThrown() {
-        new Paynow("lorem_ipsum", "", "");
+    @Test
+    @DisplayName("Paynow Constructor Three Param No Integration Id Exception Thrown")
+    void PaynowConstructorThreeParam_NoIntegrationId_ExceptionThrown() {
+        assertThrows(IllegalArgumentException.class, () -> new Paynow("lorem_ipsum", "", ""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void PaynowConstructorThreeParam_NoIntegrationKey_ExceptionThrown() {
-        new Paynow("", "lorem_ipsum", "");
+    @Test
+    @DisplayName("Paynow Constructor Three Param No Integration Key Exception Thrown")
+    void PaynowConstructorThreeParam_NoIntegrationKey_ExceptionThrown() {
+        assertThrows(IllegalArgumentException.class, () -> new Paynow("", "lorem_ipsum", ""));
     }
 
-    @Test(expected = HashMismatchException.class)
-    public void PollTransaction_ResponseStringWithBadHash_ResponseIsReturnedWithCorrectValues() throws IOException {
-
+    @Test
+    @DisplayName("Poll Transaction Response String With Bad Hash Response Is Returned With Correct Values")
+    void PollTransaction_ResponseStringWithBadHash_ResponseIsReturnedWithCorrectValues() throws Exception {
         String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68&hash=WrongHash";
         String pollUrl = "www.dummypollurl.co.zw";
-
         when(httpClient.postAsync(pollUrl, null)).thenReturn(rawResponse);
 
-        paynow.pollTransaction(pollUrl);
+        assertThrows(HashMismatchException.class, () -> paynow.pollTransaction(pollUrl));
     }
 
-    @Test(expected = HashMismatchException.class)
-    public void PollTransaction_ResponseStringWithNoHash_ResponseIsReturnedWithCorrectValues() throws IOException {
-
+    @Test
+    @DisplayName("Poll Transaction Response String With No Hash Response Is Returned With Correct Values")
+    void PollTransaction_ResponseStringWithNoHash_ResponseIsReturnedWithCorrectValues() throws Exception {
         String rawResponse = "reference=Invoice+32&paynowreference=1234567&amount=3.50&status=Created&pollurl=https%3a%2f%2fwww.paynow.co.zw%2fInterface%2fCheckPayment%2f%3fguid%3d06f656ab-ed60-4a03-8373-a3321b4b3e68";
         String pollUrl = "www.dummypollurl.co.zw";
-
         when(httpClient.postAsync(pollUrl, null)).thenReturn(rawResponse);
 
-        paynow.pollTransaction(pollUrl);
+        assertThrows(HashMismatchException.class, () -> paynow.pollTransaction(pollUrl));
     }
 
-    @Test(expected = ConnectionException.class)
-    public void PollTransaction_ExceptionOccursDuringExecution_ExceptionIsCaughtAndCustomExceptionIsThrown() throws IOException {
-
+    @Test
+    @DisplayName("Poll Transaction Exception Occurs During Execution Exception Is Caught And Custom Exception Is Thrown")
+    void PollTransaction_ExceptionOccursDuringExecution_ExceptionIsCaughtAndCustomExceptionIsThrown() throws Exception {
         String pollUrl = "www.dummypollurl.co.zw";
-
         when(httpClient.postAsync(pollUrl, null)).thenThrow(new IOException());
 
-        paynow.pollTransaction(pollUrl);
-
+        assertThrows(ConnectionException.class, () -> paynow.pollTransaction(pollUrl));
     }
 
 }

--- a/src/test/java/zw/co/paynow/parsers/PaymentParserTest.java
+++ b/src/test/java/zw/co/paynow/parsers/PaymentParserTest.java
@@ -1,20 +1,21 @@
 package zw.co.paynow.parsers;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class PaymentParserTest {
+@DisplayName("Payment Parser Test")
+class PaymentParserTest {
 
     private HashMap<String, BigDecimal> items;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         items = new HashMap<>();
         items.put("Bananas", new BigDecimal(1));
         items.put("Apple", new BigDecimal(2));
@@ -22,28 +23,30 @@ public class PaymentParserTest {
     }
 
     @Test
-    public void FlattenCollection_ItemsSetInInit_CorrectStringFromMap() {
-        assertEquals("Apple, Bananas, Oranges", PaymentParser.flattenCollection(items));
+    @DisplayName("Flatten Collection Items Set In Init Correct String From Map")
+    void FlattenCollection_ItemsSetInInit_CorrectStringFromMap() {
+        assertThat(PaymentParser.flattenCollection(items)).isEqualTo("Apple, Bananas, Oranges");
     }
 
     @Test
-    public void FlattenCollection_EmptyMap_CorrectStringFromMap() {
+    @DisplayName("Flatten Collection Empty Map Correct String From Map")
+    void FlattenCollection_EmptyMap_CorrectStringFromMap() {
         items.clear();
-        assertEquals("", PaymentParser.flattenCollection(items));
+        assertThat(PaymentParser.flattenCollection(items)).isEmpty();
     }
 
     @Test
-    public void AddCollectionValues_ItemsSetInInit_CorrectTotal() {
+    @DisplayName("Add Collection Values Items Set In Init Correct Total")
+    void AddCollectionValues_ItemsSetInInit_CorrectTotal() {
         BigDecimal total = PaymentParser.addCollectionValues(items);
-        assertTrue(new BigDecimal(6).compareTo(total) == 0);
+        assertThat(total).isEqualByComparingTo(new BigDecimal(6));
     }
 
     @Test
-    public void AddCollectionValues_EmptyMap_CorrectTotal() {
+    @DisplayName("Add Collection Values Empty Map Correct Total")
+    void AddCollectionValues_EmptyMap_CorrectTotal() {
         items.clear();
         BigDecimal total = PaymentParser.addCollectionValues(items);
-        assertTrue(new BigDecimal(0).compareTo(total) == 0);
+        assertThat(total).isEqualByComparingTo(new BigDecimal(0));
     }
-
-
 }

--- a/src/test/java/zw/co/paynow/parsers/UrlParserTest.java
+++ b/src/test/java/zw/co/paynow/parsers/UrlParserTest.java
@@ -1,32 +1,35 @@
 package zw.co.paynow.parsers;
-
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class UrlParserTest {
+@DisplayName("Url Parser Test")
+class UrlParserTest {
 
     @Test
-    public void UrlEncode_SampleStringAsParam_CorrectUrlEncodedString() {
+    @DisplayName("Url Encode Sample String As Param Correct Url Encoded String")
+    void UrlEncode_SampleStringAsParam_CorrectUrlEncodedString() {
         String sampleUnencodedUrl = "https://www.google.com/search?q=searching+some+info";
         String expectedEncodedUrl = "https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dsearching%2Bsome%2Binfo";
         String result = UrlParser.urlEncode(sampleUnencodedUrl);
-        assertEquals(expectedEncodedUrl, result);
+        assertThat(result).isEqualTo(expectedEncodedUrl);
     }
 
     @Test
-    public void UrlDecode_SampleStringAsParam_CorrectUrlDecodedString() {
+    @DisplayName("Url Decode Sample String As Param Correct Url Decoded String")
+    void UrlDecode_SampleStringAsParam_CorrectUrlDecodedString() {
         String sampleEncodedUrl = "https%3A%2F%2Fwww.google.com%2Fsearch%3Fq%3Dsearching%2Bsome%2Binfo";
         String expectedDecodedUrl = "https://www.google.com/search?q=searching+some+info";
         String result = UrlParser.urlDecode(sampleEncodedUrl);
-        assertEquals(expectedDecodedUrl, result);
+        assertThat(result).isEqualTo(expectedDecodedUrl);
     }
 
     @Test
-    public void UrlEncode_SampleMapAsParam_CorrectUrlEncodedString() {
-
+    @DisplayName("Url Encode Sample Map As Param Correct Url Encoded String")
+    void UrlEncode_SampleMapAsParam_CorrectUrlEncodedString() {
         HashMap<String, String> hashMap = new HashMap();
         hashMap.put("1", "one");
         hashMap.put("2", "two");
@@ -34,24 +37,24 @@ public class UrlParserTest {
 
         String expectedString = "1=one&2=two&3=three";
         String result = UrlParser.parseQueryStringFromMap(hashMap);
-        assertEquals(expectedString, result);
+        assertThat(result).isEqualTo(expectedString);
 
     }
 
     @Test
-    public void UrlEncode_EmptyMapAsParam_EmptyString() {
-
+    @DisplayName("Url Encode Empty Map As Param Empty String")
+    void UrlEncode_EmptyMapAsParam_EmptyString() {
         HashMap<String, String> hashMap = new HashMap();
 
         String expectedString = "";
         String result = UrlParser.parseQueryStringFromMap(hashMap);
-        assertEquals(expectedString, result);
+        assertThat(result).isEqualTo(expectedString);
 
     }
 
     @Test
-    public void ParseQueryString_SampleQueryString_MapWithCorrectValues() {
-
+    @DisplayName("Parse Query String Sample Query String Map With Correct Values")
+    void ParseQueryString_SampleQueryString_MapWithCorrectValues() {
         String sampleQueryString = "1=one&2=two&3=three";
 
         HashMap<String, String> expectedHashMap = new HashMap<>();
@@ -60,19 +63,19 @@ public class UrlParserTest {
         expectedHashMap.put("3", "three");
 
         HashMap<String, String> result = UrlParser.parseMapFromQueryString(sampleQueryString);
-        assertEquals(expectedHashMap, result);
+        assertThat(result).isEqualTo(expectedHashMap);
 
     }
 
     @Test
-    public void ParseQueryString_EmptyQueryString_EmptyMap() {
-
+    @DisplayName("Parse Query String Empty Query String Empty Map")
+    void ParseQueryString_EmptyQueryString_EmptyMap() {
         String sampleQueryString = "";
 
         HashMap<String, String> expectedHashMap = new HashMap<>();
 
         HashMap<String, String> result = UrlParser.parseMapFromQueryString(sampleQueryString);
-        assertEquals(expectedHashMap, result);
+        assertThat(result).isEqualTo(expectedHashMap);
 
     }
 

--- a/src/test/java/zw/co/paynow/responses/MobileInitResponseTest.java
+++ b/src/test/java/zw/co/paynow/responses/MobileInitResponseTest.java
@@ -1,18 +1,19 @@
 package zw.co.paynow.responses;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import zw.co.paynow.constants.TransactionStatus;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class MobileInitResponseTest {
+@DisplayName("Mobile Init Response Test")
+class MobileInitResponseTest {
 
     @Test
-    public void MobileInitResponseConstructor_SampleMapAsParam_InstantiatedObjectWithCorrectValues() {
-
+    @DisplayName("Mobile Init Response Constructor Sample Map As Param Instantiated Object With Correct Values")
+    void MobileInitResponseConstructor_SampleMapAsParam_InstantiatedObjectWithCorrectValues() {
         HashMap<String, String> sampleMap = new HashMap<>();
         sampleMap.put("paynowreference", "0123456");
         sampleMap.put("instructions", "Some_random_instructions");
@@ -21,13 +22,13 @@ public class MobileInitResponseTest {
         sampleMap.put("status", "Ok");
 
         MobileInitResponse response = new MobileInitResponse(sampleMap);
-        assertEquals(TransactionStatus.OK, response.getStatus());
-        assertTrue(response.success());
-        assertEquals(0, response.getErrors().size());
-        assertEquals("0123456", response.getPaynowReference());
-        assertEquals(sampleMap.get("hash"), response.getHash());
-        assertEquals(sampleMap.get("instructions"), response.getInstructions());
-        assertEquals(sampleMap.get("pollurl"), response.getPollUrl());
+        assertThat(response.getStatus()).isEqualTo(TransactionStatus.OK);
+        assertThat(response.success()).isTrue();
+        assertThat(response.getErrors().size()).isZero();
+        assertThat(response.getPaynowReference()).isEqualTo("0123456");
+        assertThat(response.getHash()).isEqualTo(sampleMap.get("hash"));
+        assertThat(response.getInstructions()).isEqualTo(sampleMap.get("instructions"));
+        assertThat(response.getPollUrl()).isEqualTo(sampleMap.get("pollurl"));
 
     }
 

--- a/src/test/java/zw/co/paynow/responses/StatusResponseTest.java
+++ b/src/test/java/zw/co/paynow/responses/StatusResponseTest.java
@@ -1,19 +1,20 @@
 package zw.co.paynow.responses;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import zw.co.paynow.constants.TransactionStatus;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class StatusResponseTest {
+@DisplayName("Status Response Test")
+class StatusResponseTest {
 
     @Test
-    public void StatusResponseConstructor_SampleMapAsParam_InstantiatedObjectWithCorrectValues() {
-
+    @DisplayName("Status Response Constructor Sample Map As Param Instantiated Object With Correct Values")
+    void StatusResponseConstructor_SampleMapAsParam_InstantiatedObjectWithCorrectValues() {
         HashMap<String, String> sampleMap = new HashMap<>();
         sampleMap.put("reference", "a1");
         sampleMap.put("paynowreference", "b2");
@@ -22,13 +23,13 @@ public class StatusResponseTest {
         sampleMap.put("status", "Sent");
 
         StatusResponse response = new StatusResponse(sampleMap);
-        assertEquals(TransactionStatus.SENT, response.getStatus());
-        assertTrue(response.success());
-        assertEquals(0, response.getErrors().size());
-        assertEquals(new BigDecimal(sampleMap.get("amount")), response.getAmount());
-        assertEquals(sampleMap.get("hash"), response.hash());
-        assertEquals(sampleMap.get("reference"), response.getMerchantReference());
-        assertEquals(sampleMap.get("paynowreference"), response.getPaynowReference());
+        assertThat(response.getStatus()).isEqualTo(TransactionStatus.SENT);
+        assertThat(response.success()).isTrue();
+        assertThat(response.getErrors().size()).isZero();
+        assertThat(response.getAmount()).isEqualTo(new BigDecimal(sampleMap.get("amount")));
+        assertThat(response.hash()).isEqualTo(sampleMap.get("hash"));
+        assertThat(response.getMerchantReference()).isEqualTo(sampleMap.get("reference"));
+        assertThat(response.getPaynowReference()).isEqualTo(sampleMap.get("paynowreference"));
 
     }
 

--- a/src/test/java/zw/co/paynow/responses/WebInitResponseTest.java
+++ b/src/test/java/zw/co/paynow/responses/WebInitResponseTest.java
@@ -1,18 +1,19 @@
 package zw.co.paynow.responses;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import zw.co.paynow.constants.TransactionStatus;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class WebInitResponseTest {
+@DisplayName("Web Init Response Test")
+class WebInitResponseTest {
 
     @Test
-    public void WebInitResponseConstructor_SampleMapAsParam_InstantiatedObjectWithCorrectValues() {
-
+    @DisplayName("Web Init Response Constructor Sample Map As Param Instantiated Object With Correct Values")
+    void WebInitResponseConstructor_SampleMapAsParam_InstantiatedObjectWithCorrectValues() {
         HashMap<String, String> sampleMap = new HashMap<>();
         sampleMap.put("browserurl", "https://www.paynow.co.zw/Interface/Redirect/?guid=09471727-37a6-4a0c-a7f3-c1ac48f79431");
         sampleMap.put("pollurl", "https://www.paynow.co.zw/Interface/CheckPayment/?guid=09471727-37a6-4a0c-a7f3-c1ac48f79431");
@@ -20,12 +21,12 @@ public class WebInitResponseTest {
         sampleMap.put("status", "Ok");
 
         WebInitResponse response = new WebInitResponse(sampleMap);
-        assertEquals(TransactionStatus.OK, response.getStatus());
-        assertTrue(response.success());
-        assertEquals(0, response.getErrors().size());
-        assertEquals(sampleMap.get("hash"), response.getHash());
-        assertEquals(sampleMap.get("browserurl"), response.getRedirectURL());
-        assertEquals(sampleMap.get("pollurl"), response.getPollUrl());
+        assertThat(response.getStatus()).isEqualTo(TransactionStatus.OK);
+        assertThat(response.success()).isTrue();
+        assertThat(response.getErrors().size()).isZero();
+        assertThat(response.getHash()).isEqualTo(sampleMap.get("hash"));
+        assertThat(response.getRedirectURL()).isEqualTo(sampleMap.get("browserurl"));
+        assertThat(response.getPollUrl()).isEqualTo(sampleMap.get("pollurl"));
 
     }
 

--- a/src/test/java/zw/co/paynow/validators/EmailValidatorTest.java
+++ b/src/test/java/zw/co/paynow/validators/EmailValidatorTest.java
@@ -1,30 +1,33 @@
 package zw.co.paynow.validators;
 
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class EmailValidatorTest {
+@DisplayName("Email Validator Test")
+class EmailValidatorTest {
 
     @Test
-    public void StatusResponseConstructor_ValidEmail_InstantiatedObjectWithCorrectValues() {
+    @DisplayName("Status Response Constructor Valid Email Instantiated Object With Correct Values")
+    void StatusResponseConstructor_ValidEmail_InstantiatedObjectWithCorrectValues() {
         String email = "example@example.org";
         boolean result = EmailValidator.validateEmail(email);
-        assertTrue(result);
+        assertThat(result).isTrue();
     }
 
     @Test
-    public void StatusResponseConstructor_InvalidEmail_InstantiatedObjectWithCorrectValues() {
+    @DisplayName("Status Response Constructor Invalid Email Instantiated Object With Correct Values")
+    void StatusResponseConstructor_InvalidEmail_InstantiatedObjectWithCorrectValues() {
         String badEmail1 = "example";
         String badEmail2 = "example.org";
         String badEmail3 = "example@org";
         boolean result1 = EmailValidator.validateEmail(badEmail1);
         boolean result2 = EmailValidator.validateEmail(badEmail2);
         boolean result3 = EmailValidator.validateEmail(badEmail3);
-        assertFalse(result1);
-        assertFalse(result2);
-        assertFalse(result3);
+        assertThat(result1).isFalse();
+        assertThat(result2).isFalse();
+        assertThat(result3).isFalse();
     }
 
 }


### PR DESCRIPTION
- Upgraded unit tests to Junit 5
- Used AssertJ along with Junit 5 as it is more readable and fluid to use.
- Added the unit test library version numbers to the `gradle.properties` file.
- I didn't include the production library versions in the `gradle.properties` file for now as I do not want to break any production code with unit test changes. That could be done as a separate task.